### PR TITLE
CMake Pthreads Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,9 @@ if (NOT OGRE_BUILD_PLATFORM_IPHONE)
         find_package(Boost COMPONENTS program_options filesystem QUIET)
         set(OGRE_LIBRARIES ${OGRE_LIBRARIES} ${Boost_LIBRARIES})
 
+	# Find Threads
+	find_package (Threads REQUIRED)
+
         if(QGears_BUILD_TESTS)
             find_package(Boost COMPONENTS unit_test_framework QUIET)
             set(QGears_TEST_LIBRARIES

--- a/QGearsMain/CMakeLists.txt
+++ b/QGearsMain/CMakeLists.txt
@@ -301,17 +301,18 @@ endif()
 set(LIBRARIES
     ${OGRE_LIBRARIES}
     ${OIS_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
     LuaBind
     TinyXml
     FinalFantasy7
 )
 
-target_link_libraries(QGearsMain ${LIBRARIES})
+target_link_libraries(QGearsMain ${LIBRARIES} )
 
 set(LIBRARIES
     QGearsMain
 )
-target_link_libraries(q-gears    ${LIBRARIES})
+target_link_libraries(q-gears ${LIBRARIES})
 
 install(TARGETS q-gears
     DESTINATION ./


### PR DESCRIPTION
I updated both the main CMakeLists.txt and QGearsMain/CMakeLists.txt to
search for the pthreads library. I have Ogre built with threads enabled
but the linker was throwing an error when trying to link the executable.
It couldn't find pthread even though libprthread was installed.
