### PR TITLE
added numpad keys to Console::Input

### DIFF
--- a/QGearsMain/include/core/Console.h
+++ b/QGearsMain/include/core/Console.h
@@ -43,6 +43,7 @@ private:
     void LoadHistory();
     void SaveHistory();
     void AddToHistory(const Ogre::String& history);
+    char TranslateNumpad(const QGears::Event& event);
 
     int                           m_ConsoleWidth;
     int                           m_ConsoleHeight;

--- a/QGearsMain/include/core/Logger.h
+++ b/QGearsMain/include/core/Logger.h
@@ -10,6 +10,7 @@
 #define LOG_ERROR( message ) Ogre::LogManager::getSingleton().logMessage( "[ERROR] " + Ogre::String( __FILE__ ) + " " + Ogre::StringConverter::toString( __LINE__ ) + ": " + message, Ogre::LML_CRITICAL )
 #define LOG_WARNING( message ) Ogre::LogManager::getSingleton().logMessage( "[WARNING] " + Ogre::String( __FILE__ ) + " " + Ogre::StringConverter::toString( __LINE__ ) + ": " + message, Ogre::LML_NORMAL )
 #define LOG_TRIVIAL( message ) Ogre::LogManager::getSingleton().logMessage( message, Ogre::LML_TRIVIAL )
+#define LOG_CONSOLE( message) Ogre::LogManager::getSingleton().logMessage( message, Ogre::LML_NORMAL )
 
 #ifdef _MSC_VER
 #define LOG_DEBUG_EX( message ) Ogre::LogManager::getSingleton().logMessage( "[DEBUG] (" +  __FILE__ + " " + Ogre::StringConverter::toString( __LINE__ ) + ")(" + std::string( __FUNCTION__ ) + "): " + message, Ogre::LML_CRITICAL )

--- a/QGearsMain/src/core/Console.cpp
+++ b/QGearsMain/src/core/Console.cpp
@@ -297,7 +297,7 @@ Console::Input(const QGears::Event& event)
     // input ascii character
     else if ((event.type == QGears::ET_KEY_PRESS || event.type == QGears::ET_KEY_REPEAT) && m_InputLine.size() < m_LineWidth)
     {
-        char legalchars[] = "ABCDEFGHIJKLMNOPQRSTUVWXUZabcdefghijklmnopqrstuvwxyz1234567890~!@#$%^&*()-_=+?{[]}|\\;:'\"<>,./? ";
+        char legalchars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890~!@#$%^&*()-_=+?{[]}|\\;:'\"<>,./? ";
         char txt = TranslateNumpad(event);
 
         for (unsigned int c = 0; c < sizeof(legalchars) - 1; ++c)

--- a/QGearsMain/src/core/Console.cpp
+++ b/QGearsMain/src/core/Console.cpp
@@ -117,7 +117,7 @@ Console::Input(const QGears::Event& event)
     }
 
     // input command
-    else if (event.type == QGears::ET_KEY_PRESS && event.param1 == OIS::KC_RETURN && m_InputLine.size())
+    else if (event.type == QGears::ET_KEY_PRESS && (event.param1 == OIS::KC_RETURN || event.param1 == OIS::KC_NUMPADENTER) && m_InputLine.size())
     {
         if(m_AutoCompletition.size() > 0)
         {
@@ -298,8 +298,9 @@ Console::Input(const QGears::Event& event)
     else if ((event.type == QGears::ET_KEY_PRESS || event.type == QGears::ET_KEY_REPEAT) && m_InputLine.size() < m_LineWidth)
     {
         char legalchars[] = "ABCDEFGHIJKLMNOPQRSTUVWXUZabcdefghijklmnopqrstuvwxyz1234567890~!@#$%^&*()-_=+?{[]}|\\;:'\"<>,./? ";
-        char txt = static_cast<char>(event.param2);
-        for(unsigned int c = 0; c < sizeof(legalchars ) - 1; ++c)
+        char txt = TranslateNumpad(event);
+
+        for (unsigned int c = 0; c < sizeof(legalchars) - 1; ++c)
         {
             if(legalchars[c] == txt)
             {
@@ -313,6 +314,45 @@ Console::Input(const QGears::Event& event)
     }
 }
 
+
+char
+Console::TranslateNumpad(const QGears::Event& event)
+{
+    switch (static_cast<int>(event.param1))
+    {
+    case OIS::KC_NUMPAD0:
+        return '0';
+    case OIS::KC_NUMPAD1:
+        return '1';
+    case OIS::KC_NUMPAD2:
+        return '2';
+    case OIS::KC_NUMPAD3:
+        return '3';
+    case OIS::KC_NUMPAD4:
+        return '4';
+    case OIS::KC_NUMPAD5:
+        return '5';
+    case OIS::KC_NUMPAD6:
+        return '6';
+    case OIS::KC_NUMPAD7:
+        return '7';
+    case OIS::KC_NUMPAD8:
+        return '8';
+    case OIS::KC_NUMPAD9:
+        return '9';
+    case OIS::KC_DECIMAL:
+        return '.';
+    case OIS::KC_ADD:
+        return '+';
+    case OIS::KC_SUBTRACT:
+        return '-';
+    case OIS::KC_MULTIPLY:
+        return '*';
+    case OIS::KC_DIVIDE:
+        return '/';
+    }
+    return static_cast<char>(event.param2);
+}
 
 void
 Console::Update()

--- a/QGearsMain/src/core/ScriptManager.cpp
+++ b/QGearsMain/src/core/ScriptManager.cpp
@@ -284,9 +284,20 @@ ScriptManager::Update(const ScriptManager::Type type)
 void
 ScriptManager::RunString(const Ogre::String& lua)
 {
+    int preEvalIndex = lua_gettop(m_LuaState);
     if(luaL_dostring(m_LuaState, lua.c_str()) == 1)
     {
         LOG_ERROR(Ogre::String(lua_tostring(m_LuaState, -1)));
+    }
+    else
+    {
+        int index = lua_gettop(m_LuaState);
+        if (index > 0 && index != preEvalIndex)
+        {
+            auto str = lua_tostring(m_LuaState, index);
+            LOG_CONSOLE(str != nullptr ? str : "(nullptr; try tostring(...)?)");
+            lua_pop(m_LuaState, 1);
+        }
     }
 }
 


### PR DESCRIPTION
added expression eval output to ScriptManager::RunString. to evaluate an expression use 'return <expr>'. some things need conversion to string first; use 'return tostring(<expr>)'